### PR TITLE
Initial Html Processing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -522,6 +522,7 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "clap",
+ "ego-tree",
  "env_logger",
  "log",
  "once_cell",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ default-run = "om-wikiparser"
 [dependencies]
 anyhow = { version = "1.0.71", features = ["backtrace"] }
 clap = { version = "4.3.2", features = ["derive"] }
+ego-tree = "0.6.2"
 env_logger = "0.10.0"
 log = "0.4.18"
 once_cell = "1.18.0"

--- a/README.md
+++ b/README.md
@@ -35,6 +35,10 @@ As an example of usage with the map generator:
 # Transform intermediate files from generator.
 cut -f 2 id_to_wikidata.csv > wikidata_ids.txt
 tail -n +2 wiki_urls.txt | cut -f 3 > wikipedia_urls.txt
+# Enable backtraces in errors and panics.
+export RUST_BACKTRACE=1
+# Set log level to debug
+export RUST_LOG=om_wikiparser=debug
 # Begin extraction.
 for dump in $DUMP_DOWNLOAD_DIR/*-ENTERPRISE-HTML.json.tar.gz
 do

--- a/src/bin/simplify_html.rs
+++ b/src/bin/simplify_html.rs
@@ -7,6 +7,11 @@ use std::io::{stdin, stdout, Read, Write};
 use om_wikiparser::html::simplify;
 
 fn main() -> anyhow::Result<()> {
+    env_logger::Builder::new()
+        .filter_level(log::LevelFilter::Info)
+        .parse_default_env()
+        .try_init()?;
+
     let mut input = String::new();
     stdin().read_to_string(&mut input)?;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -138,6 +138,8 @@ fn write(
 }
 
 fn main() -> anyhow::Result<()> {
+    // Use info level by default, load overrides from `RUST_LOG` env variable.
+    // See https://docs.rs/env_logger/latest/env_logger/index.html#example
     env_logger::Builder::new()
         .filter_level(log::LevelFilter::Info)
         .parse_default_env()


### PR DESCRIPTION
While I'm waiting for more dump files to download, I got started with this.

This PR will bring the html output to functional parity with the scraped ones.
There will still be extra metadata and other bloat covered in #4.

Remaining steps:
- [x] convert all relative articles to absolute
- [x] Remove `img`/`picture` elements
- [x] Make sure interwiki links are handled correctly
- [x] Merge #6
