### PR TITLE
Handle simplification panics

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -101,7 +101,9 @@ log "Extracting tags from '$OSM_FILE'"
 "$wikiparser" get-tags "$OSM_FILE" > osm_tags.tsv
 
 # Enable backtraces in errors and panics.
-export RUST_BACKTRACE=1
+# NOTE: Backtraces are still printed for panics that are caught higher in the stack.
+# export RUST_BACKTRACE=1
+
 # Set log level.
 export RUST_LOG=om_wikiparser=info
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -102,7 +102,7 @@ fn main() -> anyhow::Result<()> {
             stdin().read_to_string(&mut input)?;
 
             let start = Instant::now();
-            let output = om_wikiparser::html::simplify(&input, &lang);
+            let output = om_wikiparser::html::simplify(&input, &lang)?;
             let stop = Instant::now();
             let time = stop.duration_since(start);
 


### PR DESCRIPTION
I've tested manually and it:
- handles panics with a static message or formatted arguments
- logs an error instead of exiting (backtraces are still printed)
- writes any panic-causing html to an `errors/` subdirectory
