### PR TITLE
cargo: Enable LTO

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,3 +31,5 @@ urlencoding = "2.1.2"
 
 [profile.release]
 overflow-checks = true
+lto = true
+codegen-units = 1


### PR DESCRIPTION
Enabled https://doc.rust-lang.org/cargo/reference/profiles.html#lto on builds to allow the linker to optimize the outputted binary.